### PR TITLE
sepolicy: Remove execmod rules for cameraserver

### DIFF
--- a/domain.te
+++ b/domain.te
@@ -436,7 +436,6 @@ neverallow * {
   -apk_data_file
   -app_data_file
   -asec_public_file
-  -system_file
 }:file execmod;
 
 # Do not allow making the stack or heap executable.
@@ -446,8 +445,7 @@ neverallow * self:process { execstack execheap };
 
 # prohibit non-zygote spawned processes from using shared libraries
 # with text relocations. b/20013628 .
-#camera_server neverallow needed for Android N
-neverallow { domain -appdomain userdebug_or_eng(`-camera -cameraserver')} file_type:file execmod;
+neverallow { domain -appdomain } file_type:file execmod;
 neverallow { domain -init } proc:{ file dir } mounton;
 
 # Ensure that all types assigned to processes are included


### PR DESCRIPTION
This change reverts:

     https://gerrit.omnirom.org/#/c/19484

which was forcing the creation of camera.te definition (camera domain).
It was required for deprecated (at 7.1.1) mako (nexus 4).

Also this change fix build process for devices that do not have camera.te
definition.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I399c06293a94c14b33d8fc638baf336656b516b6